### PR TITLE
Add animated results shelf for filtered portfolio cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^11.0.17",
         "next": "14.0.3",
         "react": "^18",
         "react-dom": "^18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2681,6 +2681,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3833,6 +3860,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "full": "npm run build && npm run start"
   },
   "dependencies": {
+    "framer-motion": "^11.0.17",
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,26 @@
+'use client'
+import { useMemo } from 'react'
 import { About } from '../components/About'
 import { Contact } from '../components/Contact'
-import { Experience } from '../components/Experience'
+import { Experience, experienceCardItems } from '../components/Experience'
 import { Footer } from '../components/Footer'
 import { Header } from '../components/Header'
 import { Hero } from '../components/Hero'
-import { Projects } from '../components/Projects'
-import { Skills } from '../components/Skills'
+import { Projects, projectCardItems } from '../components/Projects'
+import ResultsShelf from '../components/ResultsShelf'
+import { Skills, highlightCardItems } from '../components/Skills'
 
 export default function Home() {
+  const items = useMemo(
+    () => [...projectCardItems, ...highlightCardItems, ...experienceCardItems],
+    []
+  )
+
   return (
     <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
       <Header />
       <main>
+        <ResultsShelf items={items} />
         <Hero />
         <About />
         <Skills />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { About } from '../components/About'
 import { Contact } from '../components/Contact'
 import { Experience, experienceCardItems } from '../components/Experience'
+import FilterBar from '../components/FilterBar'
 import { Footer } from '../components/Footer'
 import { Header } from '../components/Header'
 import { Hero } from '../components/Hero'
@@ -20,6 +21,7 @@ export default function Home() {
     <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
       <Header />
       <main>
+        <FilterBar />
         <ResultsShelf items={items} />
         <Hero />
         <About />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { GlassCard } from './GlassCard'
 import useActiveFilters from './useActiveFilters'
 
@@ -8,21 +8,17 @@ export function About() {
   const active = filters.size > 0
 
   return (
-    <motion.section
-      id="about"
-      layout
-      animate={{
-        height: active ? 0 : 'auto',
-        opacity: active ? 0 : 1,
-        marginTop: active ? 0 : undefined,
-        marginBottom: active ? 0 : undefined,
-      }}
-      style={{
-        overflow: active ? 'hidden' : undefined,
-        pointerEvents: active ? 'none' : 'auto',
-      }}
-      className="section-wrapper py-16 lg:py-20"
-    >
+    <AnimatePresence initial={false}>
+      {!active && (
+        <motion.section
+          key="about"
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ duration: 0.3, ease: 'easeInOut' }}
+          className="section-wrapper py-16 lg:py-20"
+          style={{ overflow: 'hidden' }}
+        >
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
         <GlassCard className="p-6 md:p-8">
           <h2 className="section-heading">About</h2>
@@ -56,6 +52,8 @@ export function About() {
           </ul>
         </GlassCard>
       </div>
-    </motion.section>
+        </motion.section>
+      )}
+    </AnimatePresence>
   )
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,34 +1,61 @@
+'use client'
+import { motion } from 'framer-motion'
 import { GlassCard } from './GlassCard'
+import useActiveFilters from './useActiveFilters'
 
 export function About() {
+  const filters = useActiveFilters()
+  const active = filters.size > 0
+
   return (
-<section id="about" className="section-wrapper py-16 lg:py-20">
-  <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
-    <GlassCard className="p-6 md:p-8">
-      <h2 className="section-heading">About</h2>
-      <p className="mt-4 leading-relaxed text-[var(--muted)]">
-        I’m a backend engineer focused on <strong>building resilient, high-performance platforms</strong> that keep critical experiences online. 
-        At <strong>PNC Bank</strong>, I design and maintain <strong>high-volume Java and Kafka microservices</strong> powering customer communications, 
-        leading initiatives that improved scalability, reduced cost, and enhanced reliability across 50+ applications. 
-        My approach combines <strong>disciplined engineering</strong>, deep system observability, and cross-team collaboration 
-        to ship software that scales confidently and runs efficiently.
-      </p>
-      <p className="mt-4 leading-relaxed text-[var(--muted)]">
-        I actively integrate <strong>AI-assisted development tools</strong> into my workflow, including GitHub Copilot in IntelliJ, PyCharm, and VS Code, as well as OpenAI Codex for rapid prototyping and documentation. This enables me to accelerate boilerplate creation, maintain focus on architecture and logic, and deliver production-quality solutions faster.
-      </p>
-    </GlassCard>
+    <motion.section
+      id="about"
+      layout
+      animate={{
+        height: active ? 0 : 'auto',
+        opacity: active ? 0 : 1,
+        marginTop: active ? 0 : undefined,
+        marginBottom: active ? 0 : undefined,
+      }}
+      style={{
+        overflow: active ? 'hidden' : undefined,
+        pointerEvents: active ? 'none' : 'auto',
+      }}
+      className="section-wrapper py-16 lg:py-20"
+    >
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr)]">
+        <GlassCard className="p-6 md:p-8">
+          <h2 className="section-heading">About</h2>
+          <p className="mt-4 leading-relaxed text-[var(--muted)]">
+            I’m a backend engineer focused on <strong>building resilient, high-performance platforms</strong> that keep critical experiences online.
+            At <strong>PNC Bank</strong>, I design and maintain <strong>high-volume Java and Kafka microservices</strong> powering customer communications,
+            leading initiatives that improved scalability, reduced cost, and enhanced reliability across 50+ applications.
+            My approach combines <strong>disciplined engineering</strong>, deep system observability, and cross-team collaboration
+            to ship software that scales confidently and runs efficiently.
+          </p>
+          <p className="mt-4 leading-relaxed text-[var(--muted)]">
+            I actively integrate <strong>AI-assisted development tools</strong> into my workflow, including GitHub Copilot in IntelliJ, PyCharm, and VS Code, as well as OpenAI Codex for rapid prototyping and documentation. This enables me to accelerate boilerplate creation, maintain focus on architecture and logic, and deliver production-quality solutions faster.
+          </p>
+        </GlassCard>
 
-    <GlassCard className="p-6 md:p-8">
-      <h3 className="text-xl font-semibold text-[var(--text)]">What I&apos;m focusing on</h3>
-      <ul className="mt-4 list-disc space-y-2 pl-5 text-[var(--muted)]">
-        <li><strong>Scaling</strong> Spring Boot and Kafka-based systems with intelligent autoscaling and lag-aware rebalancing.</li>
-        <li><strong>Automating</strong> CI/CD pipelines and resilience testing to streamline deployments across OpenShift environments.</li>
-        <li><strong>Optimizing</strong> data workflows and observability pipelines to improve insights and reduce operational overhead.</li>
-        <li><strong>Leveraging</strong> AI-assisted tools like GitHub Copilot and Codex to accelerate development and maintain code quality.</li>
-      </ul>
-    </GlassCard>
-  </div>
-</section>
-
+        <GlassCard className="p-6 md:p-8">
+          <h3 className="text-xl font-semibold text-[var(--text)]">What I&apos;m focusing on</h3>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-[var(--muted)]">
+            <li>
+              <strong>Scaling</strong> Spring Boot and Kafka-based systems with intelligent autoscaling and lag-aware rebalancing.
+            </li>
+            <li>
+              <strong>Automating</strong> CI/CD pipelines and resilience testing to streamline deployments across OpenShift environments.
+            </li>
+            <li>
+              <strong>Optimizing</strong> data workflows and observability pipelines to improve insights and reduce operational overhead.
+            </li>
+            <li>
+              <strong>Leveraging</strong> AI-assisted tools like GitHub Copilot and Codex to accelerate development and maintain code quality.
+            </li>
+          </ul>
+        </GlassCard>
+      </div>
+    </motion.section>
   )
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { GlassCard } from './GlassCard'
 
 const socials = [

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -83,6 +83,8 @@ export function Experience({ items = experienceCardItems }: { items?: CardItem[]
   const filters = useActiveFilters()
   const active = filters.size > 0
 
+  if (active) return null
+
   return (
     <section id="experience" className="section-wrapper py-16 lg:py-20">
       <div className="max-w-3xl">

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,6 +1,13 @@
+'use client'
+import { LayoutGroup } from 'framer-motion'
+import MotionCard from './MotionCard'
+import useActiveFilters from './useActiveFilters'
+import { matches } from './match'
 import { GlassCard } from './GlassCard'
+import type { CardItem } from './ResultsShelf'
 
 type Role = {
+  id: string
   company: string
   title: string
   period: string
@@ -10,22 +17,24 @@ type Role = {
 
 const roles: Role[] = [
   {
+    id: 'role-pnc',
     company: 'PNC Bank',
     title: 'Software Engineer',
     period: '2022 — Present',
     location: 'Remote',
     achievements: [
-    'Delivered and maintained 50+ Java microservices handling 5k+ TPS for enterprise SMS banking.',
-    'Solely designed and implemented a new bulk messaging platform using Spring Batch and Kafka, reducing end-to-end processing time from 7 hours to 1.5 hours while scaling to 4M+ records.',
-    'Integrated Resilience4j circuit breakers to enhance fault tolerance and failover handling for high-throughput messaging pipelines.',
-    'Analyzed cluster-wide resource usage and reduced total JVM and memory consumption by 200GB through autoscaling optimization, profiling, and performance analytics.',
-    'Led the cloud migration of 15 legacy services to OpenShift with automated resilience and load testing pipelines.',
-    'Improved customer onboarding by 25% by launching auto-enrollment and proactive messaging flows.',
-    'Enhanced observability and incident response through Dynatrace dashboards, distributed tracing, and runbook automation.',
-    'Adopted AI-assisted tools (Copilot, Codex) to streamline development, improve test coverage generation, and maintain consistent code documentation across Java and Python services.',
+      'Delivered and maintained 50+ Java microservices handling 5k+ TPS for enterprise SMS banking.',
+      'Solely designed and implemented a new bulk messaging platform using Spring Batch and Kafka, reducing end-to-end processing time from 7 hours to 1.5 hours while scaling to 4M+ records.',
+      'Integrated Resilience4j circuit breakers to enhance fault tolerance and failover handling for high-throughput messaging pipelines.',
+      'Analyzed cluster-wide resource usage and reduced total JVM and memory consumption by 200GB through autoscaling optimization, profiling, and performance analytics.',
+      'Led the cloud migration of 15 legacy services to OpenShift with automated resilience and load testing pipelines.',
+      'Improved customer onboarding by 25% by launching auto-enrollment and proactive messaging flows.',
+      'Enhanced observability and incident response through Dynatrace dashboards, distributed tracing, and runbook automation.',
+      'Adopted AI-assisted tools (Copilot, Codex) to streamline development, improve test coverage generation, and maintain consistent code documentation across Java and Python services.',
     ],
   },
   {
+    id: 'role-libertine',
     company: 'The Libertine Pub',
     title: 'Assistant Manager',
     period: '2021 — 2022',
@@ -36,6 +45,7 @@ const roles: Role[] = [
     ],
   },
   {
+    id: 'role-lpg',
     company: 'The Litigation Practice Group',
     title: 'Operations Coordinator',
     period: '2020 — 2021',
@@ -47,7 +57,32 @@ const roles: Role[] = [
   },
 ]
 
-export function Experience() {
+export const experienceCardItems: CardItem[] = roles.map((role) => ({
+  id: role.id,
+  title: `${role.title} @ ${role.company}`,
+  texts: [role.company, role.title, role.location, role.achievements],
+  render: () => (
+    <GlassCard className="p-6 md:p-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold text-[var(--text)]">{role.title}</h3>
+          <p className="text-sm text-[var(--muted)]">{role.company} · {role.location}</p>
+        </div>
+        <p className="text-sm font-medium text-[var(--muted)]">{role.period}</p>
+      </div>
+      <ul className="mt-4 list-disc space-y-2 pl-5 text-sm leading-6 text-[var(--muted)]">
+        {role.achievements.map((achievement) => (
+          <li key={achievement}>{achievement}</li>
+        ))}
+      </ul>
+    </GlassCard>
+  ),
+}))
+
+export function Experience({ items = experienceCardItems }: { items?: CardItem[] }) {
+  const filters = useActiveFilters()
+  const active = filters.size > 0
+
   return (
     <section id="experience" className="section-wrapper py-16 lg:py-20">
       <div className="max-w-3xl">
@@ -56,24 +91,23 @@ export function Experience() {
           A track record of owning outcomes, mentoring teams, and elevating operations.
         </p>
       </div>
-      <div className="mt-8 space-y-6">
-        {roles.map((role) => (
-          <GlassCard key={role.company} className="p-6 md:p-8">
-            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-              <div>
-                <h3 className="text-xl font-semibold text-[var(--text)]">{role.title}</h3>
-                <p className="text-sm text-[var(--muted)]">{role.company} · {role.location}</p>
-              </div>
-              <p className="text-sm font-medium text-[var(--muted)]">{role.period}</p>
-            </div>
-            <ul className="mt-4 list-disc space-y-2 pl-5 text-sm leading-6 text-[var(--muted)]">
-              {role.achievements.map((achievement) => (
-                <li key={achievement}>{achievement}</li>
-              ))}
-            </ul>
-          </GlassCard>
-        ))}
-      </div>
+      <LayoutGroup>
+        <div className="mt-8 space-y-6">
+          {items.map((item) => {
+            const isMatch = matches(item.texts, filters)
+            return (
+              <MotionCard
+                key={item.id}
+                id={item.id}
+                dimmed={active && !isMatch}
+                collapsed={active && !isMatch}
+              >
+                {item.render()}
+              </MotionCard>
+            )
+          })}
+        </div>
+      </LayoutGroup>
     </section>
   )
 }

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,80 @@
+'use client'
+import { GlassCard } from './GlassCard'
+import useActiveFilters from './useActiveFilters'
+
+const availableFilters = [
+  'Java',
+  'Kafka', 
+  'OpenShift',
+  'Scaling',
+  'Kubernetes'
+]
+
+function setFiltersInURL(filters: Set<string>) {
+  const url = new URL(window.location.href)
+  if (filters.size === 0) {
+    url.searchParams.delete('filters')
+  } else {
+    url.searchParams.set('filters', Array.from(filters).join(','))
+  }
+  window.history.pushState({}, '', url.toString())
+  
+  // Removed auto-scroll to test gap issue
+  
+  // Dispatch custom event to notify other components
+  window.dispatchEvent(new CustomEvent('filterchange', { 
+    detail: { filters: Array.from(filters) } 
+  }))
+}
+
+export default function FilterBar() {
+  const activeFilters = useActiveFilters()
+
+  const toggleFilter = (filter: string) => {
+    const newFilters = new Set<string>()
+    if (!activeFilters.has(filter)) {
+      newFilters.add(filter)
+    }
+    setFiltersInURL(newFilters)
+  }
+
+  const clearAllFilters = () => {
+    setFiltersInURL(new Set())
+  }
+
+  // Use the same beautiful styling whether filters are active or not
+
+  return (
+    <div
+      className="border-b border-[var(--border)] bg-[rgba(11,15,23,0.85)] backdrop-blur-md"
+    >
+      <div className="section-wrapper py-4">
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-[var(--text)]">Filter by Technology</h3>
+            {activeFilters.size > 0 && (
+              <button
+                onClick={clearAllFilters}
+                className="text-xs text-[var(--muted)] hover:text-[var(--accent)] transition-colors"
+              >
+                Clear filter
+              </button>
+            )}
+          </div>
+          
+          <div className="flex flex-wrap gap-2">
+            {availableFilters.map((filter) => (
+              <span
+                key={filter}
+                onClick={() => toggleFilter(filter)}
+                className="inline-flex items-center rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[var(--muted)] cursor-pointer hover:border-[var(--accent)] hover:text-[var(--accent)] transition-colors duration-200"
+              >
+                {filter}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 export function Footer() {
   return (
     <footer className="section-wrapper py-10 text-sm text-[var(--muted)]">

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { ReactNode } from 'react'
 
 interface GlassCardProps {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Link from 'next/link'
 
 const navLinks = [

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,12 +1,32 @@
+'use client'
+import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { GlassCard } from './GlassCard'
+import useActiveFilters from './useActiveFilters'
 
 export function Hero() {
+  const filters = useActiveFilters()
+  const active = filters.size > 0
+
   return (
-    <section id="top" className="section-wrapper pt-24 pb-20">
+    <motion.section
+      id="top"
+      layout
+      animate={{
+        height: active ? 0 : 'auto',
+        opacity: active ? 0 : 1,
+        marginTop: active ? 0 : undefined,
+        marginBottom: active ? 0 : undefined,
+      }}
+      style={{
+        overflow: active ? 'hidden' : undefined,
+        pointerEvents: active ? 'none' : 'auto',
+      }}
+      className="section-wrapper pt-24 pb-20"
+    >
       <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr),minmax(0,1.1fr)] lg:items-center">
         <div className="flex min-h-full items-center justify-center lg:items-center">
-          <GlassCard className="flex h-56 w-56 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface)] text-3xl font-semibold text-[var(--text)] shadow-glass overflow-hidden">
+          <GlassCard className="flex h-56 w-56 items-center justify-center overflow-hidden rounded-full border border-[var(--border)] bg-[var(--surface)] text-3xl font-semibold text-[var(--text)] shadow-glass">
             <img
               src="/images/projects/IMG_4601.jpg"
               alt="Haedon Kaufman"
@@ -40,6 +60,6 @@ export function Hero() {
           </div>
         </div>
       </div>
-    </section>
+    </motion.section>
   )
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
 import { GlassCard } from './GlassCard'
 import useActiveFilters from './useActiveFilters'
@@ -9,21 +9,17 @@ export function Hero() {
   const active = filters.size > 0
 
   return (
-    <motion.section
-      id="top"
-      layout
-      animate={{
-        height: active ? 0 : 'auto',
-        opacity: active ? 0 : 1,
-        marginTop: active ? 0 : undefined,
-        marginBottom: active ? 0 : undefined,
-      }}
-      style={{
-        overflow: active ? 'hidden' : undefined,
-        pointerEvents: active ? 'none' : 'auto',
-      }}
-      className="section-wrapper pt-24 pb-20"
-    >
+    <AnimatePresence initial={false}>
+      {!active && (
+        <motion.section
+          key="hero"
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ duration: 0.3, ease: 'easeInOut' }}
+          className="section-wrapper pt-24 pb-20"
+          style={{ overflow: 'hidden' }}
+        >
       <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr),minmax(0,1.1fr)] lg:items-center">
         <div className="flex min-h-full items-center justify-center lg:items-center">
           <GlassCard className="flex h-56 w-56 items-center justify-center overflow-hidden rounded-full border border-[var(--border)] bg-[var(--surface)] text-3xl font-semibold text-[var(--text)] shadow-glass">
@@ -60,6 +56,8 @@ export function Hero() {
           </div>
         </div>
       </div>
-    </motion.section>
+        </motion.section>
+      )}
+    </AnimatePresence>
   )
 }

--- a/src/components/MotionCard.tsx
+++ b/src/components/MotionCard.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { motion } from 'framer-motion'
+import { ReactNode } from 'react'
+
+export default function MotionCard({
+  id,
+  children,
+  className,
+  dimmed = false,
+  collapsed = false,
+}: {
+  id: string
+  children: ReactNode
+  className?: string
+  dimmed?: boolean
+  collapsed?: boolean
+}) {
+  return (
+    <motion.div
+      layout
+      layoutId={`card-${id}`}
+      initial={false}
+      animate={{
+        opacity: dimmed ? 0.55 : 1,
+        scale: dimmed ? 0.98 : 1,
+        height: collapsed ? 0 : 'auto',
+        marginTop: collapsed ? 0 : undefined,
+        marginBottom: collapsed ? 0 : undefined,
+      }}
+      transition={{ type: 'spring', stiffness: 420, damping: 36, mass: 0.8 }}
+      className={className}
+      style={{ overflow: collapsed ? 'hidden' : undefined }}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,6 +1,13 @@
+'use client'
+import { LayoutGroup } from 'framer-motion'
+import MotionCard from './MotionCard'
+import useActiveFilters from './useActiveFilters'
+import { matches } from './match'
 import { GlassCard } from './GlassCard'
+import type { CardItem } from './ResultsShelf'
 
 interface Project {
+  id: string
   title: string
   summary: string
   stack: string[]
@@ -8,8 +15,9 @@ interface Project {
   links: { label: string; href: string }[]
 }
 
-const projects = [
+const projects: Project[] = [
   {
+    id: 'bulk-messaging-system',
     title: 'Bulk Messaging System',
     summary:
       'High-throughput batch and Kafka-based messaging system replacing legacy ETL workflows for large-scale customer notifications at PNC Bank.',
@@ -26,9 +34,9 @@ const projects = [
     links: [],
   },
   {
+    id: 'sms-banking-integrations',
     title: 'SMS Banking Integrations',
-    summary:
-      'Modernized messaging services powering multi-channel customer notifications at PNC Bank.',
+    summary: 'Modernized messaging services powering multi-channel customer notifications at PNC Bank.',
     stack: ['Java 21', 'Spring Boot', 'Kafka', 'OpenShift'],
     achievements: [
       'Handled 5k+ transactions per second with resilient Kafka consumer groups and short-circuiting patterns.',
@@ -41,6 +49,7 @@ const projects = [
     links: [],
   },
   {
+    id: 'recipe-ai-platform',
     title: 'Recipe AI Platform',
     summary:
       'Semantic recipe discovery engine with ingestion pipeline for 200k+ records and personalized search results.',
@@ -62,8 +71,53 @@ const projects = [
   },
 ]
 
+export const projectCardItems: CardItem[] = projects.map((project) => ({
+  id: `project-${project.id}`,
+  title: project.title,
+  texts: [project.title, project.summary, project.stack, project.achievements],
+  render: () => (
+    <GlassCard className="flex h-full flex-col justify-between p-6">
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-xl font-semibold text-[var(--text)]">{project.title}</h3>
+          <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{project.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
+          {project.stack.map((item) => (
+            <span key={item} className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-1">
+              {item}
+            </span>
+          ))}
+        </div>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-[var(--muted)]">
+          {project.achievements.map((achievement) => (
+            <li key={achievement}>{achievement}</li>
+          ))}
+        </ul>
+      </div>
+      {project.links.length > 0 && (
+        <div className="mt-6 flex flex-wrap gap-3">
+          {project.links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-2xl border border-[var(--border)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text)] transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-[var(--surface)] hover:shadow-lg hover:shadow-black/40 focus-visible:-translate-y-0.5"
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </GlassCard>
+  ),
+}))
 
-export function Projects() {
+export function Projects({ items = projectCardItems }: { items?: CardItem[] }) {
+  const filters = useActiveFilters()
+  const active = filters.size > 0
+
   return (
     <section id="projects" className="section-wrapper py-16 lg:py-20">
       <div className="flex flex-col gap-6">
@@ -73,43 +127,23 @@ export function Projects() {
             Selected work showcasing delivery of stable, data-informed platforms.
           </p>
         </div>
-        <div className="grid gap-6 lg:grid-cols-2">
-          {projects.map((project) => (
-            <GlassCard key={project.title} className="flex h-full flex-col justify-between p-6">
-              <div className="space-y-4">
-                <div>
-                  <h3 className="text-xl font-semibold text-[var(--text)]">{project.title}</h3>
-                  <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{project.summary}</p>
-                </div>
-                <div className="flex flex-wrap gap-2 text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
-                  {project.stack.map((item) => (
-                    <span key={item} className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3 py-1">
-                      {item}
-                    </span>
-                  ))}
-                </div>
-                <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-[var(--muted)]">
-                  {project.achievements.map((achievement) => (
-                    <li key={achievement}>{achievement}</li>
-                  ))}
-                </ul>
-              </div>
-              <div className="mt-6 flex flex-wrap gap-3">
-                {project.links.map((link) => (
-                  <a
-                    key={link.href}
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center rounded-2xl border border-[var(--border)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--text)] transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-[var(--surface)] hover:shadow-lg hover:shadow-black/40 focus-visible:-translate-y-0.5"
-                  >
-                    {link.label}
-                  </a>
-                ))}
-              </div>
-            </GlassCard>
-          ))}
-        </div>
+        <LayoutGroup>
+          <div className="grid gap-6 lg:grid-cols-2">
+            {items.map((it) => {
+              const isMatch = matches(it.texts, filters)
+              return (
+                <MotionCard
+                  key={it.id}
+                  id={it.id}
+                  dimmed={active && !isMatch}
+                  collapsed={active && !isMatch}
+                >
+                  {it.render()}
+                </MotionCard>
+              )
+            })}
+          </div>
+        </LayoutGroup>
       </div>
     </section>
   )

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -118,6 +118,8 @@ export function Projects({ items = projectCardItems }: { items?: CardItem[] }) {
   const filters = useActiveFilters()
   const active = filters.size > 0
 
+  if (active) return null
+
   return (
     <section id="projects" className="section-wrapper py-16 lg:py-20">
       <div className="flex flex-col gap-6">

--- a/src/components/ResultsShelf.tsx
+++ b/src/components/ResultsShelf.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { LayoutGroup, motion, AnimatePresence } from 'framer-motion'
+import useActiveFilters from './useActiveFilters'
+import { matches } from './match'
+import MotionCard from './MotionCard'
+
+export type CardItem = {
+  id: string
+  title: string
+  texts: (string | string[] | undefined)[]
+  render: () => JSX.Element
+}
+
+export default function ResultsShelf({ items }: { items: CardItem[] }) {
+  const filters = useActiveFilters()
+  const active = filters.size > 0
+  const subset = active ? items.filter((i) => matches(i.texts, filters)) : []
+
+  return (
+    <AnimatePresence initial={false}>
+      {active && (
+        <motion.div
+          key="shelf"
+          initial={{ y: -16, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -16, opacity: 0 }}
+          className="sticky top-16 z-40 border-b border-[var(--border)] bg-[rgba(11,15,23,0.72)] backdrop-blur-md"
+        >
+          <div className="section-wrapper py-4">
+            <div className="mb-3 text-sm text-[var(--muted)]">
+              Showing {subset.length} result{subset.length === 1 ? '' : 's'} for filters in URL
+            </div>
+            <LayoutGroup>
+              <div className="grid gap-6 md:grid-cols-2">
+                {subset.map((it) => (
+                  <MotionCard key={`s-${it.id}`} id={it.id}>
+                    {it.render()}
+                  </MotionCard>
+                ))}
+              </div>
+            </LayoutGroup>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/ResultsShelf.tsx
+++ b/src/components/ResultsShelf.tsx
@@ -14,34 +14,43 @@ export type CardItem = {
 export default function ResultsShelf({ items }: { items: CardItem[] }) {
   const filters = useActiveFilters()
   const active = filters.size > 0
-  const subset = active ? items.filter((i) => matches(i.texts, filters)) : []
+
+  // ⛔️ If no active filters, unmount the ENTIRE shelf (no space left behind)
+  if (!active) return null
+
+  const subset = items.filter((i) => matches(i.texts, filters))
 
   return (
-    <AnimatePresence initial={false}>
-      {active && (
+    <motion.div
+      key="shelf"
+      initial={{ y: -16, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      exit={{ y: -16, opacity: 0 }}
+      className="sticky top-32 z-40 border-b border-[var(--border)] bg-[rgba(11,15,23,0.72)] backdrop-blur-md"
+    >
+      <div className="section-wrapper py-4">
+        <div className="mb-3 text-sm text-[var(--muted)]">
+          Showing {subset.length} result{subset.length === 1 ? '' : 's'}
+        </div>
+
+        {/* 2) Animate to height:0 when subset is empty */}
         <motion.div
-          key="shelf"
-          initial={{ y: -16, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          exit={{ y: -16, opacity: 0 }}
-          className="sticky top-16 z-40 border-b border-[var(--border)] bg-[rgba(11,15,23,0.72)] backdrop-blur-md"
+          layout
+          initial={false}
+          animate={{
+            opacity: subset.length === 0 ? 0 : 1,
+            height: subset.length === 0 ? 0 : 'auto',
+          }}
+          transition={{ duration: 0.35, ease: 'easeInOut' }}
+          className="grid gap-6 md:grid-cols-2 overflow-hidden" // ← no min-h here
         >
-          <div className="section-wrapper py-4">
-            <div className="mb-3 text-sm text-[var(--muted)]">
-              Showing {subset.length} result{subset.length === 1 ? '' : 's'} for filters in URL
-            </div>
-            <LayoutGroup>
-              <div className="grid gap-6 md:grid-cols-2">
-                {subset.map((it) => (
-                  <MotionCard key={`s-${it.id}`} id={it.id}>
-                    {it.render()}
-                  </MotionCard>
-                ))}
-              </div>
-            </LayoutGroup>
-          </div>
+          {subset.map((it) => (
+            <MotionCard key={`s-${it.id}`} id={it.id}>
+              {it.render()}
+            </MotionCard>
+          ))}
         </motion.div>
-      )}
-    </AnimatePresence>
+      </div>
+    </motion.div>
   )
 }

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -94,6 +94,8 @@ export function Skills({ items = highlightCardItems }: { items?: CardItem[] }) {
   const filters = useActiveFilters()
   const active = filters.size > 0
 
+  if (active) return null
+
   return (
     <section id="skills" className="section-wrapper py-16 lg:py-20">
       <div className="flex flex-col gap-6">

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,4 +1,10 @@
+'use client'
+import { LayoutGroup } from 'framer-motion'
+import MotionCard from './MotionCard'
+import useActiveFilters from './useActiveFilters'
+import { matches } from './match'
 import { GlassCard } from './GlassCard'
+import type { CardItem } from './ResultsShelf'
 
 const skills = [
   {
@@ -25,6 +31,7 @@ const skills = [
 
 export const highlights = [
   {
+    id: 'highlight-kubernetes',
     title: 'Kubernetes — Scaling & Optimization',
     description:
       'Practical experience designing autoscaling and resource strategies to improve reliability and reduce cost. Focus areas include Horizontal Pod Autoscaler (HPA) for scaling pods by CPU/memory or custom metrics, Vertical Pod Autoscaler (VPA) for right-sizing pod resource requests, and using the Cluster Autoscaler for node-level scaling.',
@@ -37,6 +44,7 @@ export const highlights = [
     ],
   },
   {
+    id: 'highlight-kafka',
     title: 'Kafka — High-Throughput Messaging & Reliability',
     description:
       'Extensive experience architecting and tuning Apache Kafka for mission-critical systems requiring high throughput, message durability, and real-time processing. Skilled in optimizing producer–consumer performance, managing backpressure, and ensuring data integrity across distributed clusters.',
@@ -51,6 +59,7 @@ export const highlights = [
     ],
   },
   {
+    id: 'highlight-spring-batch',
     title: 'Spring Batch — Large-Scale Data Processing',
     description:
       'Proficient in designing scalable Spring Batch jobs for high-volume ETL and enrichment pipelines, enabling efficient, fault-tolerant data ingestion at enterprise scale.',
@@ -62,11 +71,29 @@ export const highlights = [
       'Optimized memory and commit intervals to balance throughput and stability during large-scale batch runs.',
     ],
   },
-];
+]
 
+export const highlightCardItems: CardItem[] = highlights.map((item) => ({
+  id: item.id,
+  title: item.title,
+  texts: [item.title, item.description, item.bullets],
+  render: () => (
+    <GlassCard className="p-6">
+      <h3 className="text-lg font-semibold text-[var(--text)]">{item.title}</h3>
+      <p className="mt-2 text-sm text-[var(--muted)]">{item.description}</p>
+      <ul className="mt-3 list-disc space-y-1 pl-5 text-sm text-[var(--muted)]">
+        {item.bullets.map((point) => (
+          <li key={point}>{point}</li>
+        ))}
+      </ul>
+    </GlassCard>
+  ),
+}))
 
+export function Skills({ items = highlightCardItems }: { items?: CardItem[] }) {
+  const filters = useActiveFilters()
+  const active = filters.size > 0
 
-export function Skills() {
   return (
     <section id="skills" className="section-wrapper py-16 lg:py-20">
       <div className="flex flex-col gap-6">
@@ -93,19 +120,23 @@ export function Skills() {
             </GlassCard>
           ))}
         </div>
-      <div className="mt-10 space-y-6">
-        {highlights.map((item, index) => (
-          <GlassCard key={index} className="p-6">
-            <h3 className="text-lg font-semibold text-[var(--text)]">{item.title}</h3>
-            <p className="mt-2 text-sm text-[var(--muted)]">{item.description}</p>
-            <ul className="mt-3 list-disc pl-5 text-sm text-[var(--muted)] space-y-1">
-              {item.bullets.map((point, i) => (
-                <li key={i}>{point}</li>
-              ))}
-            </ul>
-          </GlassCard>
-        ))}
-      </div>
+        <LayoutGroup>
+          <div className="mt-10 space-y-6">
+            {items.map((item) => {
+              const isMatch = matches(item.texts, filters)
+              return (
+                <MotionCard
+                  key={item.id}
+                  id={item.id}
+                  dimmed={active && !isMatch}
+                  collapsed={active && !isMatch}
+                >
+                  {item.render()}
+                </MotionCard>
+              )
+            })}
+          </div>
+        </LayoutGroup>
       </div>
     </section>
   )

--- a/src/components/match.ts
+++ b/src/components/match.ts
@@ -7,6 +7,6 @@ export function matches(texts: (string | string[] | undefined)[], filters: Set<s
   )
     .join(' | ')
     .toLowerCase()
-  for (const f of filters) if (hay.includes(f.toLowerCase())) return true
+  for (const f of Array.from(filters)) if (hay.includes(f.toLowerCase())) return true
   return false
 }

--- a/src/components/match.ts
+++ b/src/components/match.ts
@@ -1,0 +1,12 @@
+export function matches(texts: (string | string[] | undefined)[], filters: Set<string>): boolean {
+  if (filters.size === 0) return true
+  const hay = (
+    texts
+      .flatMap((t) => (Array.isArray(t) ? t : [t]))
+      .filter(Boolean) as string[]
+  )
+    .join(' | ')
+    .toLowerCase()
+  for (const f of filters) if (hay.includes(f.toLowerCase())) return true
+  return false
+}

--- a/src/components/useActiveFilters.ts
+++ b/src/components/useActiveFilters.ts
@@ -1,0 +1,32 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export function parseFiltersFromURL(): Set<string> {
+  if (typeof window === 'undefined') return new Set()
+  const qs = new URLSearchParams(window.location.search)
+  const raw = (qs.get('q') || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  return new Set(raw)
+}
+
+export default function useActiveFilters() {
+  const [filters, setFilters] = useState<Set<string>>(parseFiltersFromURL())
+
+  useEffect(() => {
+    const onPop = () => setFilters(parseFiltersFromURL())
+    const onChange = (e: Event) => {
+      const d = (e as CustomEvent).detail as { filters: string[] } | undefined
+      if (d?.filters) setFilters(new Set(d.filters))
+    }
+    window.addEventListener('popstate', onPop)
+    window.addEventListener('filterchange', onChange as any)
+    return () => {
+      window.removeEventListener('popstate', onPop)
+      window.removeEventListener('filterchange', onChange as any)
+    }
+  }, [])
+
+  return filters
+}


### PR DESCRIPTION
## Summary
- add the framer-motion dependency along with shared filter utilities and a MotionCard wrapper
- introduce a sticky ResultsShelf and register project, highlight, and experience cards for teleport-style animations
- collapse hero/about content and dim unmatched cards whenever URL filters are active

## Testing
- not run (framer-motion installation blocked by registry access in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e1acdc61d48330bf24e4a44a6b1bb5